### PR TITLE
Make split2flac dash compatible

### DIFF
--- a/split2flac
+++ b/split2flac
@@ -224,11 +224,11 @@ if [ ${SAVE} -eq 1 ]; then
 fi
 
 # use flake if possible
-which flake &>/dev/null && FLAC_ENCODER="flake" || FLAC_ENCODER="flac"
+command -v flake >/dev/null && FLAC_ENCODER="flake" || FLAC_ENCODER="flac"
 
 METAFLAC="metaflac --no-utf8-convert"
 VORBISCOMMENT="vorbiscomment -R -a"
-which mid3v2 &>/dev/null && ID3TAG="mid3v2" || ID3TAG="id3tag -2"
+command -v mid3v2 >/dev/null && ID3TAG="mid3v2" || ID3TAG="id3tag -2"
 MP4TAGS="mp4tags"
 GETTAG="cueprint -n 1 -t"
 VALIDATE="sed s/[^][[:space:][:alnum:]&_#,.'\"\(\)!-]//g"


### PR DESCRIPTION
Split2flac is incompatible with the [dash](http://gondor.apana.org.au/~herbert/dash/) (a POSIX compliant `/bin/sh` implementation) due to the use of the `&>` output redirection operator in conjunction with the `which` commands.  In order to fix this, the `&>` operator has been replaced by `>`, and (in order to avoid the outputs to stderr) `which` has been replaced by `command -v`.

Note that this could alternatively be solved by replacing the use of `&>/dev/null` with `>/dev/null 2>&1`, but I didn't like that as much.
