### PR TITLE
Remove specific invalid filename chars

### DIFF
--- a/split2flac
+++ b/split2flac
@@ -231,7 +231,13 @@ VORBISCOMMENT="vorbiscomment -R -a"
 command -v mid3v2 >/dev/null && ID3TAG="mid3v2" || ID3TAG="id3tag -2"
 MP4TAGS="mp4tags"
 GETTAG="cueprint -n 1 -t"
-VALIDATE="sed s/[^][[:space:][:alnum:]&_#,.'\"\(\)!-]//g"
+
+INVALIDCHARS=":"
+SYSTEM=$(uname -s)
+if [[ $SYSTEM == *CYGWIN_NT* ]] || [[ $SYSTEM == *MINGW32_NT* ]]; then
+    INVALIDCHARS+="/\?%*:|\"<>"
+fi
+VALIDATE="sed s/[${INVALIDCHARS}]//g"
 
 # check & print output format
 msg_format="${cG}Output format :$cZ"


### PR DESCRIPTION
Filename validation doesn't consider unicode chars. For example: cue sheets containing track details in Japanese. Removing specific invalid filename characters based on platform may be preferable.
