### PR TITLE
Check shntool and cuetools existance

### DIFF
--- a/split2flac
+++ b/split2flac
@@ -283,6 +283,14 @@ check_cuetools () {
 	fi
 }
 
+check_shntool () {
+	if ! which shnsplit 2>/dev/null ; then
+		emsg "'shnsplit' tool was not found, "
+		emsg "you should install 'shntool' package\n"
+		exit 1
+	fi
+}
+
 # splits a file
 split_file () {
 	TMPCUE="${HOME}/.split2flac_XXXXX.cue"
@@ -511,6 +519,8 @@ split_file () {
 			wav)  ENC="wav ${ENCARGS}"; REPLAY_GAIN=0;;
 			*)	  emsg "Unknown output format ${FORMAT}\n"; exit 1;;
 		esac
+
+		check_shntool
 
 		# split to tracks
 		# sed expression is a fix for "shnsplit: error: m:ss.ff format can only be used with CD-quality files"


### PR DESCRIPTION
It's better to check cuetools/shntool tools existance to avoid cryptic shell errors, like this:

```
/home/mvel/.local/bin/split2flac: line 431: [: 1: unary operator expected
Failed to get number of tracks from CUE sheet.
There may be an error in the sheet.
/home/mvel/.local/bin/split2flac: line 123: printf: `N': invalid format character
Running cueprint -n 1 -t /home/mvel/.local/bin/split2flac: line 443: cueprint: command not found
```
