### PR TITLE
fix Copy Over "cannot stat" error

### DIFF
--- a/split2flac
+++ b/split2flac
@@ -48,7 +48,7 @@ REPLAY_GAIN=0
 FORMAT="${0##*split2}"
 DIR="."
 OUTPATTERN="@artist/{@year - }@album/@track - @title.@ext"
-COPYMASKS="[Cc]overs \*.log \*.txt \*.jpg \*.cbr"
+COPYMASKS="[Cc]overs *.log *.txt *.jpg *.cbr"
 COPYFILES=1
 ENCA_ARGS=""
 
@@ -480,7 +480,11 @@ split_file () {
 	PATTERN=$(update_pattern "${PATTERN}" "ext" "${FORMAT}")
 
 	# construct output directory name
-	OUT="${DIR}"
+	if [ $(echo "$DIR" | cut -c 1) == "/" ] ; then
+		OUT="${DIR}"
+	else
+		OUT="$(pwd)/$DIR"
+	fi
 
 	if [ ${NOSUBDIRS} -eq 0 ]; then
 		# add path from the pattern
@@ -680,11 +684,11 @@ split_file () {
 		eval "for i in ${COPYMASKS}; do \
 				test -r \"\$i\" && \
 				echo \"   +> \$i\" 2>/dev/null; done"
-		cd "${old}"
 		if [ ${DRY} -ne 1 ]; then
 			eval "for i in ${COPYMASKS}; do \
-					test -r/\"${SDIR}/\$i\" && \
-					cp -r \"${SDIR}/\$i\" \"\${OUT}/\"; done"
+					test -r \"\$i\" && \
+					cp -r \"\$i\" \"\${OUT}/\"; done"
+		cd "${old}"
 		fi
 	fi
 


### PR DESCRIPTION
Force destination dir to be absolute, so as to avoid problems with wildcards in COPYMASKS
Use a consistent method for escaping wildcard and filename substitution in COPYMASKS

This fixes three issues:

 - wildcards in COPYMASKS are expanded correctly when testing for existence, but are not expanded at all in the copy command. Result: 'cannot stat' error message and nothing gets copied.
 - the copy command is executed for all items in COPYMASKS, even if they do not exist. Result: false 'cannot stat' error message.
- in COPYMASKS you use a backslash escape for "*" wildcard, but no escape for "[" filename substitution.

Example of error output, when there exists a directory called Covers, which fails to be copied, and there is nothing matching '*.log' but we still try to copy it - and fail.

"
Copying files:
   +> Covers
cp: cannot stat 'MyDir/[Cc]overs': No such file or directory
cp: cannot stat 'MyDir/*.log': No such file or directory
"